### PR TITLE
Updated iteration.lsp -- Removed redundant hash-quoting of lambda.

### DIFF
--- a/koans/iteration.lsp
+++ b/koans/iteration.lsp
@@ -112,5 +112,5 @@
 ;; ----
 
 (define-test test-mapcar-with-lambda
-    (let ((mc-result (mapcar #'(lambda (x) (mod x 10)) '(21 152 403 14))))
+    (let ((mc-result (mapcar (lambda (x) (mod x 10)) '(21 152 403 14))))
       (assert-equal mc-result ____)))


### PR DESCRIPTION
The reader macro #' is required for symbols, not for lambdas which the reader knows how to interpret. 
