### PR TITLE
Convert test-lexical-closure-over-adder function to a koan test.

### DIFF
--- a/koans/functions.lsp
+++ b/koans/functions.lsp
@@ -166,7 +166,7 @@
   This function will add n to its argument."
   (lambda (y) (+ x y)))
 
-(defun test-lexical-closure-over-adder ()
+(define-test test-lexical-closure-over-adder ()
   (let ((add-100 (adder 100))
         (add-500 (adder 500)))
   "add-100 and add-500 now refer to different bindings to x"


### PR DESCRIPTION
I supose the idea in functions.lsp was that `test-lexical-closure-over-adder` was a koan instead of a function defined with `defun`. This PR fix this.
