### PR TITLE
fix key and value in hashes

### DIFF
--- a/koans/hash-tables.lsp
+++ b/koans/hash-tables.lsp
@@ -36,7 +36,7 @@
   (assert-equal 1 (hash-table-count table-of-cube-roots))
 
   (setf (gethash 8 table-of-cube-roots) 2)
-  (setf (gethash -27 table-of-cube-roots) -3)
+  (setf (gethash -3 table-of-cube-roots) -27)
   (assert-equal ___ (gethash -3 table-of-cube-roots))
   (assert-equal ___ (hash-table-count table-of-cube-roots))
 


### PR DESCRIPTION
The key and value were in the wrong order. With this, the test will result in -27 instead of nil.
