### PR TITLE
Use bordeaux-threads in the threads koan for portability

### DIFF
--- a/.koans
+++ b/.koans
@@ -25,5 +25,5 @@
  :dice-project
  :macros
  :scope-and-extent
- #+sbcl :threads
+ :threads
 )

--- a/contemplate.lsp
+++ b/contemplate.lsp
@@ -20,8 +20,7 @@
 
 (defpackage :lisp-koans
   (:use :common-lisp)
-  (:use :lisp-unit)
-  #+sbcl (:use :sb-ext))
+  (:use :lisp-unit))
 
 (in-package :lisp-koans)
 
@@ -55,7 +54,7 @@
     (in-package :lisp-koans)
     (unless (find-package koan-group-name)
       (make-package koan-group-name
-                    :use '(:common-lisp :lisp-unit #+sbcl :sb-ext)))
+                    :use '(:common-lisp :lisp-unit)))
     (setf *package* (find-package koan-group-name))
     (load (concatenate 'string *koan-dir-name* "/" koan-file-name))
     (incf *n-total-koans* (length (list-tests)))

--- a/koans/threads.lsp
+++ b/koans/threads.lsp
@@ -12,16 +12,19 @@
 ;;   See the License for the specific language governing permissions and
 ;;   limitations under the License.
 
-;; NOTE: This koan group uses language features specific to sbcl, that are 
-;; not part of the Common Lisp specification.  If you are not using sbcl, 
-;; feel free to skip this group by removing it from '.koans'
+;; NOTE: This koan group uses language features specific to bordeaux-threads
+;; which are not part of the Common Lisp specification. Feel free to skip this
+;; group by removing it from '.koans'
+
+;; bt-semaphore is required for the semaphore class
+(require :bt-semaphore)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Making threads with sb-thread:make-thread  ;;
-;; Joining threads with sb-thread:join-thread ;;
+;; Making threads with bt:make-thread  ;;
+;; Joining threads with bt:join-thread ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; sb-thread takes a -function- as a parameter.
+;; make-thread takes a -function- as a parameter.
 ;; This function will be executed in a separate thread.
 
 ;; Since the execution order of separate threads is not guaranteed,
@@ -37,36 +40,36 @@
     using a lambda as the supplied function to execute."
   (assert-equal *greeting* "no greeting")
   (let ((greeting-thread
-         (sb-thread:make-thread
+         (bt:make-thread
           (lambda ()
             (setf *greeting* "hello world")))))
-    (sb-thread:join-thread greeting-thread)
+    (bt:join-thread greeting-thread)
     (assert-equal *greeting* "hello world")
-    (setf greeting-thread (sb-thread:make-thread #'sets-socal-greeting))
-    (sb-thread:join-thread greeting-thread)
+    (setf greeting-thread (bt:make-thread #'sets-socal-greeting))
+    (bt:join-thread greeting-thread)
     (assert-equal *greeting* ____)))
 
 
 (define-test test-join-thread-return-value
-    "the return value of the thread is passed in sb-thread:join-thread"
-  (let ((my-thread (sb-thread:make-thread
+    "the return value of the thread is passed in bt:join-thread"
+  (let ((my-thread (bt:make-thread
                     (lambda () (* 11 99)))))
-    (assert-equal ____ (sb-thread:join-thread my-thread))))
+    (assert-equal ____ (bt:join-thread my-thread))))
 
 
 (define-test test-threads-can-have-names
     "Threads can have names.  Names can be useful in diagnosing problems
      or reporting."
   (let ((empty-plus-thread
-         (sb-thread:make-thread #'+
+         (bt:make-thread #'+
                                 :name "what is the sum of no things adding?")))
-    (assert-equal (sb-thread:thread-name empty-plus-thread)
+    (assert-equal (bt:thread-name empty-plus-thread)
                   ____)))
 
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Sending arguments to the thread function: ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Simulate sending arguments to the thread function: ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun returns-hello-name (name)
   (format nil "Hello, ~a" name))
@@ -74,21 +77,22 @@
 (defun double-wrap-list (x y z)
   (list (list x y z)))
 
-;; Create a thread which will print out "Hello -Name-" using
-;; the named write-hello-name function.   Arguments are handed
-;; to threads as a list, unless there is just a single argument
-;; then it does not need to be wrapped in a list.
+;; Create a thread which will print out "Hello -Name-" using the named
+;; write-hello-name function. We cannot pass arguements directly to make
+;; thread, so we must pass a lambda that will call the function with the
+;; argument values.
 
 (define-test test-sending-arguments-to-thread
     (assert-equal "Hello, Buster" 
-                  (sb-thread:join-thread
-                   (sb-thread:make-thread 'returns-hello-name
-                                          :arguments "Buster")))
+                  (bt:join-thread
+                   (bt:make-thread
+                    (lambda ()
+                      (returns-hello-name "Buster")))))
     (assert-equal ____
-                  (sb-thread:join-thread
-                   (sb-thread:make-thread 'double-wrap-list
-                                          :arguments '(3 4 5)))))
-
+                  (bt:join-thread
+                   (bt:make-thread
+                    (lambda ()
+                      (double-wrap-list '(3 4 5)))))))
 
 ;; ----
 
@@ -122,12 +126,18 @@
     "same program as above, executed in threads.  Sleeps are simultaneous"
   (setf *accum* 0)
   (setf *before-time-millisec* (get-internal-real-time))
-  (let ((thread-1 (sb-thread:make-thread 'accum-after-time :arguments '(0.3 1)))
-        (thread-2 (sb-thread:make-thread 'accum-after-time :arguments '(0.2 2)))
-        (thread-3 (sb-thread:make-thread 'accum-after-time :arguments '(0.1 4))))
-    (sb-thread:join-thread thread-1)
-    (sb-thread:join-thread thread-2)
-    (sb-thread:join-thread thread-3))
+  (let ((thread-1 (bt:make-thread 
+                   (lambda ()
+                     (accum-after-time '(0.3 1)))))
+        (thread-2 (bt:make-thread
+                   (lambda ()
+                     (accum-after-time '(0.2 2)))))
+        (thread-3 (bt:make-thread 
+                   (lambda ()
+                     (accum-after-time '(0.1 4))))))
+    (bt:join-thread thread-1)
+    (bt:join-thread thread-2)
+    (bt:join-thread thread-3))
   (setf *after-time-millisec* (get-internal-real-time))
   (true-or-false? ___ (> (duration-ms) 200))
   (true-or-false? ___  (< (duration-ms) 400))
@@ -138,12 +148,11 @@
 ;; killing renegade threads            ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-
 (defun spawn-looping-thread (name)
   "create a never-ending looping thread with a given name"
-  (sb-thread:make-thread (lambda () (loop)) :name name))
+  (bt:make-thread (lambda () (loop)) :name name))
 
-(defvar *top-thread* sb-thread:*current-thread*)
+(defvar *top-thread* (bt:current-thread))
 (defun main-thread-p (thread) (eq thread *top-thread*))
 
 (defun kill-thread-if-not-main (thread)
@@ -151,12 +160,12 @@
  returns nil if thread is main.
  returns a 'terminated~' string otherwise"
   (unless (main-thread-p thread)
-    (sb-thread:terminate-thread thread)
-    (concatenate 'string "terminated " (sb-thread:thread-name thread))))
+    (bt:destroy-thread thread)
+    (concatenate 'string "terminated " (bt:thread-name thread))))
 
 (defun kill-spawned-threads ()
   "kill all lisp threads except the main thread."
-  (map 'list 'kill-thread-if-not-main (sb-thread:list-all-threads)))
+  (map 'list 'kill-thread-if-not-main (bt:all-threads)))
 
 (defun spawn-three-loopers ()
   "Spawn three run-aways."
@@ -166,18 +175,18 @@
     (spawn-looping-thread "looper three")))
 
 (define-test test-counting-and-killing-threads
-    "list-all-threads makes a list of all running threads in this lisp.  The sleep
+    "all-threads makes a list of all running threads in this lisp.  The sleep
      calls are necessary, as killed threads are not instantly removed from the
      list of all running threads."
-  (assert-equal ___ (length (sb-thread:list-all-threads)))
+  (assert-equal ___ (length (bt:all-threads)))
   (kill-thread-if-not-main (spawn-looping-thread "NEVER CATCH ME~!  NYA NYA!"))
   (sleep 0.01)
-  (assert-equal ___ (length (sb-thread:list-all-threads)))
+  (assert-equal ___ (length (bt:all-threads)))
   (spawn-three-loopers)
-  (assert-equal ___ (length (sb-thread:list-all-threads)))
+  (assert-equal ___ (length (bt:all-threads)))
   (kill-spawned-threads)
   (sleep 0.01)
-  (assert-equal ___ (length (sb-thread:list-all-threads))))
+  (assert-equal ___ (length (bt:all-threads))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -191,13 +200,13 @@
 
 (define-test test-threads-dont-get-bindings
     "bindings are not inherited across threads"
-  (let ((thread-ret-val (sb-thread:join-thread
-                         (sb-thread:make-thread 'returns-v))))
+  (let ((thread-ret-val (bt:join-thread
+                         (bt:make-thread 'returns-v))))
     (assert-equal thread-ret-val ____))
   (let ((*v* "LEXICAL BOUND VALUE"))
     (assert-equal *v* ____)
-    (let ((thread-ret-val (sb-thread:join-thread
-                           (sb-thread:make-thread 'returns-v))))
+    (let ((thread-ret-val (bt:join-thread
+                           (bt:make-thread 'returns-v))))
       (assert-equal thread-ret-val ____))))
 
 
@@ -226,12 +235,12 @@
 
 (define-test test-parallel-wait-and-increment
     (setf *g* 0)
-  (let ((thread-1 (sb-thread:make-thread 'waits-and-increments-g))
-        (thread-2 (sb-thread:make-thread 'waits-and-increments-g))
-        (thread-3 (sb-thread:make-thread 'waits-and-increments-g)))
-    (sb-thread:join-thread thread-1)
-    (sb-thread:join-thread thread-2)
-    (sb-thread:join-thread thread-3)
+  (let ((thread-1 (bt:make-thread 'waits-and-increments-g))
+        (thread-2 (bt:make-thread 'waits-and-increments-g))
+        (thread-3 (bt:make-thread 'waits-and-increments-g)))
+    (bt:join-thread thread-1)
+    (bt:join-thread thread-2)
+    (bt:join-thread thread-3)
     (assert-equal *g* ___)))
 
 
@@ -241,23 +250,23 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (setf *g* 0)
-(defvar *gs-mutex* (sb-thread:make-mutex :name "g's lock"))
+(defvar *gs-mutex* (bt:make-lock "g's lock"))
 
 (defun protected-increments-g (&optional (n 0.1))
-  "Surround all references to *g* within the with-mutex form."
-  (sb-thread:with-mutex (*gs-mutex*)
+  "Surround all references to *g* within the with-lock-held form."
+  (bt:with-lock-held (*gs-mutex*)
     (let ((my-remembered-g *g*))
       (sleep n)
       (setq *g* (+ 1 my-remembered-g)))))
 
 (define-test test-parallel-wait-and-increment-with-mutex
     (setf *g* 0)
-  (let ((thread-1 (sb-thread:make-thread 'protected-increments-g))
-        (thread-2 (sb-thread:make-thread 'protected-increments-g))
-        (thread-3 (sb-thread:make-thread 'protected-increments-g)))
-    (sb-thread:join-thread thread-1)
-    (sb-thread:join-thread thread-2)
-    (sb-thread:join-thread thread-3)
+  (let ((thread-1 (bt:make-thread 'protected-increments-g))
+        (thread-2 (bt:make-thread 'protected-increments-g))
+        (thread-3 (bt:make-thread 'protected-increments-g)))
+    (bt:join-thread thread-1)
+    (bt:join-thread thread-2)
+    (bt:join-thread thread-3)
     (assert-equal *g* ___)))
 
 ;;;;;;;;;;;;;;;;
@@ -265,52 +274,48 @@
 ;;;;;;;;;;;;;;;;
 
 ;; Incrementing a semaphore is an atomic operation.
-(defvar *g-semaphore* (sb-thread:make-semaphore :name "g" :count 0))
+(defvar *g-semaphore* (bt-sem:make-semaphore :name "g" :count 0))
 
 (defun semaphore-increments-g ()
-  (sb-thread:signal-semaphore *g-semaphore*))
+  (bt-sem:signal-semaphore *g-semaphore*))
 
 (define-test test-increment-semaphore
-    (assert-equal 0 (sb-thread:semaphore-count *g-semaphore*))
-  (sb-thread:join-thread (sb-thread:make-thread 'semaphore-increments-g :name "S incrementor 1"))
-  (sb-thread:join-thread (sb-thread:make-thread 'semaphore-increments-g :name "S incrementor 2"))
-  (sb-thread:join-thread (sb-thread:make-thread 'semaphore-increments-g :name "S incrementor 3"))
-  (assert-equal ___ (sb-thread:semaphore-count *g-semaphore*)))
+    (assert-equal 0 (bt-sem:semaphore-count *g-semaphore*))
+  (bt:join-thread (bt:make-thread 'semaphore-increments-g :name "S incrementor 1"))
+  (bt:join-thread (bt:make-thread 'semaphore-increments-g :name "S incrementor 2"))
+  (bt:join-thread (bt:make-thread 'semaphore-increments-g :name "S incrementor 3"))
+  (assert-equal ___ (bt-sem:semaphore-count *g-semaphore*)))
 
 
 ;; Semaphores can be used to manage resource allocation, and to trigger
 ;; threads to run when the semaphore value is above zero.
 
-(defvar *apples* (sb-thread:make-semaphore :name "how many apples" :count 0))
+(defvar *apples* (bt-sem:make-semaphore :name "how many apples" :count 0))
 (defvar *orchard-log* (make-array 10))
 (defvar *next-log-idx* 0)
-(defvar *orchard-log-mutex* (sb-thread:make-mutex :name "orchard log mutex"))
+(defvar *orchard-log-mutex* (bt:make-lock "orchard log mutex"))
 
 (defun add-to-log (item)
-  (sb-thread:with-mutex (*orchard-log-mutex*)
+  (bt:with-lock-held (*orchard-log-mutex*)
     (setf (aref *orchard-log* *next-log-idx*) item)
     (incf *next-log-idx*)))
 
 (defun apple-eater ()
-  (sb-thread:wait-on-semaphore *apples*)
+  (bt-sem:wait-on-semaphore *apples*)
   (add-to-log "apple eaten."))
 
 (defun apple-grower ()
   (sleep 0.1)
   (add-to-log "apple grown.")
-  (sb-thread:signal-semaphore *apples*))
+  (bt-sem:signal-semaphore *apples*))
 
 (defun num-apples ()
-  (sb-thread:semaphore-count *apples*))
+  (bt-sem:semaphore-count *apples*))
 
 (define-test test-orchard-simulation
     (assert-equal (num-apples) ___)
-  (let ((eater-thread (sb-thread:make-thread 'apple-eater :name "apple eater thread")))
-    (let ((grower-thread (sb-thread:make-thread 'apple-grower :name "apple grower thread")))
-      (sb-thread:join-thread eater-thread)))
+  (let ((eater-thread (bt:make-thread 'apple-eater :name "apple eater thread")))
+    (let ((grower-thread (bt:make-thread 'apple-grower :name "apple grower thread")))
+      (bt:join-thread eater-thread)))
   (assert-equal (aref *orchard-log* 0) ____)
   (assert-equal (aref *orchard-log* 1) ____))
-
-
-
-


### PR DESCRIPTION
The bordeaux-threads API is largely compatible with sb-thread, so very little had to be changed besides the package prefix. Since BT doesn't include semaphores, we use bt-semaphore for this, which provides a semaphore class that is (almost) API compatible with sb-thread.