### PR TITLE
Fix thread detection to work in SBCL implementations that don't support threading.

### DIFF
--- a/.koans
+++ b/.koans
@@ -25,5 +25,5 @@
  :dice-project
  :macros
  :scope-and-extent
- #+sbcl :threads
+ #+sb-thread :threads
 )


### PR DESCRIPTION
This version of the reader macro prevents SBCL's that don't support threading (i.e. non-Linux) from erroring out when getting to the threads koan.

TESTED: verified that thread koan works on Linux, skipped on Mac OS X.
