### PR TITLE
Fix log-form and log-form-with-value macros.

### DIFF
--- a/koans/macros.lsp
+++ b/koans/macros.lsp
@@ -108,10 +108,10 @@
 
 (defvar *log* nil)
 
-(defmacro log-form (&body body)
+(defmacro log-form (form)
   "records the body form to the list *log* and then evalues the body normally"
-  `(let ((retval ,@body))
-     (push ',@body *log*)
+  `(let ((retval ,form))
+     (push ',form *log*)
      retval))
 
 (define-test test-basic-log-form
@@ -135,11 +135,11 @@
 (defvar *log-with-value* nil)
 
 ;; you must write this macro
-(defmacro log-form-with-value (&body body)
+(defmacro log-form-with-value (form)
   "records the body form, and the form's return value
    to the list *log-with-value* and then evalues the body normally"
   `(let ((logform nil)
-         (retval ,@body))
+         (retval ,form))
 
      ;; YOUR MACRO COMPLETION CODE GOES HERE.
 


### PR DESCRIPTION
The log-form* macros can only take a single form, and in fact don't work if passed more than one form.