### PR TITLE
proposed change

### DIFF
--- a/koans/type-checking.lsp
+++ b/koans/type-checking.lsp
@@ -112,9 +112,9 @@
 
 
 (define-test test-guess-that-type!
-    (let ((x ____))
+    (let ((x (type-of ____)))
       (assert-true (subtypep  x '(SIMPLE-ARRAY T (* 3 *))))
       (assert-true (subtypep  x '(SIMPLE-ARRAY T (5 * *))))
       (assert-true (subtypep  x '(SIMPLE-ARRAY ARRAY *)))
       (assert-true (typep (make-array '(5 3 9) :element-type 'STRING ) x))
-      (assert-true (typep (make-array '(5 3 33) :element-type 'VECTOR ) x))))
+      (assert-true (typep (make-array '(5 3 9) :element-type 'VECTOR ) x))))


### PR DESCRIPTION
Hi, Thanks for this fantastic koans

When solving the type-checking koan, i thing that whe you arrive to the last Koan, this give an single (error),
I think that should change ____ with (type-of ____) then we get five fails, we can make this change or change the x by (type-of x) inside the S-expression of assert-true

Finally I'm not sure, if the purpouse is to change the array size in the last koan and then check the (type-of x), or I didn't find the correct solution. so I changed '33' to '9'

(define-test test-guess-that-type!
    (let ((x (type-of ____)))
      (assert-true (subtypep  x '(SIMPLE-ARRAY T (\* 3 *))))
      (assert-true (subtypep  x '(SIMPLE-ARRAY T (5 \* *))))
      (assert-true (subtypep  x '(SIMPLE-ARRAY ARRAY *)))
      (assert-true (typep (make-array '(5 3 9) :element-type 'STRING ) x))
      (assert-true (typep (make-array '(5 3 9) :element-type 'VECTOR ) x))))
