### PR TITLE
Add Ansi terminal colors to output

### DIFF
--- a/contemplate.lsp
+++ b/contemplate.lsp
@@ -84,8 +84,8 @@
                      #'(lambda (x) (equalp :pass x))
                      (second k-result))))
     (if all-pass-p
-        (format t "~A has expanded your awareness.~%" koan-name)
-        (format t "~A requires more meditation.~%" koan-name))))
+        (format t "[32m~A has expanded your awareness.~%[0m" koan-name)
+        (format t "[31m~A requires more meditation.~%[0m" koan-name))))
 
 (defun print-koan-group-progress (kg-name kg-results)
   (format t "~%Thinking about ~A~%" kg-name)
@@ -118,10 +118,10 @@
 (defun koan-status-message (koan-status)
   (if (find :incomplete koan-status)
        (return-from koan-status-message
-         "  A koan is incomplete.~%"))
+         "  [1m[33mA koan is incomplete.~%[0m"))
   (if (find :fail koan-status)
        (return-from koan-status-message
-         "  A koan is incorrect.~%"))
+         "  [1m[31mA koan is incorrect.~%[0m"))
   (if (find :error koan-status)
        (return-from koan-status-message
          "  A koan threw an error.~%"))
@@ -135,7 +135,7 @@
     (format t "You have not yet reached enlightenment ...~%")
     (format t (koan-status-message koan-status))
     (format t "~%")
-    (format t "Please meditate on the following code:~%")
+    (format t "[1mPlease meditate on the following code:~%[0m")
     (format t "   File \"~A/~A.lsp\"~%" *koan-dir-name* (string-downcase filename))
     (format t "   Koan \"~A\"~%" koan-name)
     (format t "   Current koan assert status is \"~A\"~%" (reverse koan-status))))


### PR DESCRIPTION
I thought it would be nice to add some red/green to the terminal
output. I did this by wrapping some of the output strings with
terminal codes ([reference][0]).

If there is a more portable, lispy way to do this, feel free to close
the PR.

[0]:http://wiki.bash-hackers.org/scripting/terminalcodes


<img width="567" alt="screen shot 2015-12-21 at 5 59 27 pm" src="https://cloud.githubusercontent.com/assets/13190980/11946343/7059aa0c-a80e-11e5-9491-eb1487f223f3.png">