### PR TITLE
Remove assignment of hash table to 'values' variable

### DIFF
--- a/koans/hash-tables.lsp
+++ b/koans/hash-tables.lsp
@@ -119,7 +119,7 @@
 (define-test test-make-your-own-hash-table
     "make a hash table that meets the following conditions"
   (let ((colors (make-hash-table))
-        (values (make-hash-table)))
+        values)
 
     (assert-equal (hash-table-count colors) 4)
     (setf values (list (gethash "blue" colors)


### PR DESCRIPTION
Not sure if the assignment of a new hash table to 'values' was intentional or not, but it was confusing to me at first. This change should make the intent of the test clearer.