### PR TITLE
reword test-transpose-using-mapcar doc string

### DIFF
--- a/koans/mapcar-and-reduce.lsp
+++ b/koans/mapcar-and-reduce.lsp
@@ -31,8 +31,8 @@
 
 
 (define-test test-transpose-using-mapcar
-    "Replace WRONG-FUNCTION with the correct function (don't forget
-     the #') to take the 'transpose'."
+    "Replace the usage of WRONG-FUNCTION in 'transpose' with the
+     correct lisp function (don't forget the #')."
   (defun WRONG-FUNCTION-1 (&rest rest) '())
   (defun transpose (L) (apply #'mapcar (cons #'WRONG-FUNCTION-1 L)))
   (assert-equal '((1 4 7)


### PR DESCRIPTION
While working through the `mapcar-and-reduce.lsp` koans I got stuck on the `test-transpose-using-mapcar` exercise.

I thought, based on the doc-string, that I was supposed to rename `WRONG-FUNCTION` and modify it.

I eventually got the test to pass by modifying `WRONG-FUNCTION` to be:

```lisp
 (defun WRONG-FUNCTION-1 (&rest rest) rest) ;; replaced '() with rest
```
When I read the doc-string for `test-mapcar-and-reduce` it was much clearer what I was supposed to do (remove usage of `WRONG-FUNCTION` and replace it with a built-in lisp function) and I went back and fixed my `test-transpose-using-mapcar` solution.

I tried re-wording the string to be a little clearer up front.