### PR TITLE
Corrected package name collision problem detected by clisp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ You are now 0/169 koans and 0/25 lessons closer to reaching enlightenment
 ```
 
 This indicates that the script has completed, and that the learner should look
-to asserts.lsp to locate and fix the problem.  The problem will be within 
+to asserts.lsp to locate and fix the problem.  The problem will be within
 a define-test expression such as
 
     (define-test assert-true
         "t is true.  Replace the blank with a t"
         (assert-true ___))
 
-In this case, the test is incomplete, and the student should fill 
+In this case, the test is incomplete, and the student should fill
 in the blank (____) with appropriate lisp code to make the assert pass.
 
 
@@ -40,7 +40,7 @@ and paste code into the lisp command line REPL.
 Quoting the Ruby Koans instructions::
 -------------------------------------
 
-   "In test-driven development the mantra has always been, red, green, 
+   "In test-driven development the mantra has always been, red, green,
 refactor. Write a failing test and run it (red), make the test pass (green),
 then refactor it (that is look at the code and see if you can make it any
 better). In this case you will need to run the koan and see it fail (red), make

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ Getting Started
 
 From a terminal, execute your lisp interpreter on the file 'contemplate.lsp' e.g.
 
+    abcl --noinform --noinit --load contemplate.lsp --eval '(quit)'
+    ccl -n -l contemplate.lsp -e '(quit)'
+    clisp -q -norc -ansi contemplate.lsp
+    ecl --norc --load contemplate.lsp --eval '(quit)'
     sbcl --script contemplate.lsp
 
 Running on a fresh version should output the following:

--- a/contemplate.lsp
+++ b/contemplate.lsp
@@ -15,8 +15,8 @@
 
 (in-package :cl-user)
 
-;; Though Clozure / CCL runs lisp-koans on the command line using 
-;; "ccl -l contemplate.lsp", the following lines are needed to 
+;; Though Clozure / CCL runs lisp-koans on the command line using
+;; "ccl -l contemplate.lsp", the following lines are needed to
 ;; meditate on the koans within the CCL IDE.
 ;; (The :hemlock is used to distiguish between ccl commandline and the IDE)
 #+(and :ccl :hemlock)

--- a/contemplate.lsp
+++ b/contemplate.lsp
@@ -54,17 +54,21 @@
 ;; Functions for loading koans ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defun package-name-from-group-name (group-name)
+  (format nil "COM.GOOGLE.LISP-KOANS.KOANS.~:@(~A~)" group-name))
+
 (defun load-koan-group-named (koan-group-name)
   ;; Creates a package for the koan-group based on koan-group-name.
   ;; Loads a lisp file at *koan-dir-name* / koan-group-name .lsp
   ;; Adds all the koans from that file to the package.
-  (let ((koan-file-name (concatenate 'string (string-downcase (string koan-group-name)) ".lsp")))
+  (let* ((koan-file-name    (concatenate 'string (string-downcase (string koan-group-name)) ".lsp"))
+         (koan-package-name (package-name-from-group-name koan-group-name)))
     (if *dp-loading* (format t "start loading ~A ~%" koan-file-name))
     (in-package :lisp-koans)
-    (unless (find-package koan-group-name)
-      (make-package koan-group-name
+    (unless (find-package koan-package-name)
+      (make-package koan-package-name
                     :use '(:common-lisp :lisp-unit #+sbcl :sb-ext)))
-    (setf *package* (find-package koan-group-name))
+    (setf *package* (find-package koan-package-name))
     (load (concatenate 'string *koan-dir-name* "/" koan-file-name))
     (incf *n-total-koans* (length (list-tests)))
     (in-package :lisp-koans)
@@ -80,7 +84,7 @@
   ;; Executes the koan group, using run-koans defined in lisp-unit
   ;; returning a test-results object.
   (if *dp-loading* (format t "start running ~A ~%" koan-group-name))
-  (run-koans koan-group-name))
+  (run-koans (package-name-from-group-name koan-group-name)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Functions for printing progress ;;

--- a/koans/asserts.lsp
+++ b/koans/asserts.lsp
@@ -39,7 +39,7 @@
     (assert-equal ___ "hello world"))
 
 (define-test test-true-or-false
-    "sometimes you will be asked to evaluate whether statements 
+    "sometimes you will be asked to evaluate whether statements
      are true (t) or false (nil)"
     (true-or-false? ___ (equal 34 34))
     (true-or-false? ___ (equal 19 78)))

--- a/koans/mapcar-and-reduce.lsp
+++ b/koans/mapcar-and-reduce.lsp
@@ -17,8 +17,8 @@
      of a list using mapcar."
   (defun times-two (x) (* x 2))
   (assert-equal ____ (mapcar #'times-two '(1 2 3)))
-  (assert-equal ____ (mapcar #'first '((3 2 1) 
-                                      ("little" "small" "tiny") 
+  (assert-equal ____ (mapcar #'first '((3 2 1)
+                                      ("little" "small" "tiny")
                                       ("pigs" "hogs" "swine")))))
 
 
@@ -36,10 +36,10 @@
   (defun WRONG-FUNCTION-1 (&rest rest) '())
   (defun transpose (L) (apply #'mapcar (cons #'WRONG-FUNCTION-1 L)))
   (assert-equal '((1 4 7)
-                  (2 5 8) 
-                  (3 6 9)) 
-                (transpose '((1 2 3) 
-                             (4 5 6) 
+                  (2 5 8)
+                  (3 6 9))
+                (transpose '((1 2 3)
+                             (4 5 6)
                              (7 8 9))))
   (assert-equal '(("these" "pretzels" "are")
                   ("making" "me" "thirsty"))
@@ -76,7 +76,7 @@
     "mapcar and reduce are a powerful combination.
      insert the correct function names, instead of WRONG-FUNCTION-X
      to define an inner product."
-  (defun inner (x y) 
+  (defun inner (x y)
     (reduce #'WRONG-FUNCTION-2 (mapcar #'WRONG-FUNCTION-3 x y)))
   (assert-equal 32 (inner '(1 2 3) '(4 5 6)))
   (assert-equal 310 (inner '(10 20 30) '(4 3 7))))

--- a/koans/scope-and-extent.lsp
+++ b/koans/scope-and-extent.lsp
@@ -15,7 +15,7 @@
 
 (defun shadow-z (z)
 ;; reuses the symbol name z to build a return value
-;; returns a list like (value-of-z, 2) 
+;; returns a list like (value-of-z, 2)
   (cons z
         (cons (let ((z 2)) z)
               nil)))

--- a/koans/special-forms.lsp
+++ b/koans/special-forms.lsp
@@ -126,7 +126,7 @@
 
 (define-test test-limits-of-case
     "case is not suitable for all kinds of values, because
-     it uses the function eql for comparisons. We will explore 
+     it uses the function eql for comparisons. We will explore
      the implications of this in the equality-distinctions lesson"
   (let* ((name "John")
          (lastname (case name ("John" "Doe")

--- a/koans/threads.lsp
+++ b/koans/threads.lsp
@@ -12,8 +12,8 @@
 ;;   See the License for the specific language governing permissions and
 ;;   limitations under the License.
 
-;; NOTE: This koan group uses language features specific to sbcl, that are 
-;; not part of the Common Lisp specification.  If you are not using sbcl, 
+;; NOTE: This koan group uses language features specific to sbcl, that are
+;; not part of the Common Lisp specification.  If you are not using sbcl,
 ;; feel free to skip this group by removing it from '.koans'
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -80,7 +80,7 @@
 ;; then it does not need to be wrapped in a list.
 
 (define-test test-sending-arguments-to-thread
-    (assert-equal "Hello, Buster" 
+    (assert-equal "Hello, Buster"
                   (sb-thread:join-thread
                    (sb-thread:make-thread 'returns-hello-name
                                           :arguments "Buster")))

--- a/lisp-unit.lsp
+++ b/lisp-unit.lsp
@@ -15,22 +15,22 @@ Modifications were made to:
 #|
 Copyright (c) 2004-2005 Christopher K. Riesbeck
 
-Permission is hereby granted, free of charge, to any person obtaining 
-a copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the 
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included 
+The above copyright notice and this permission notice shall be included
 in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR 
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, 
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 
@@ -523,7 +523,7 @@ assertion.")
     (t nil)))
 
 (defun internal-assert
-       (type form code-thunk expected-thunk extras test)  
+       (type form code-thunk expected-thunk extras test)
   "Perform the assertion and record the results."
   (let* ((expected (multiple-value-list (funcall expected-thunk)))
          (actual (multiple-value-list (funcall code-thunk)))


### PR DESCRIPTION
You may ignore the first commit which removes trailing whitespaces, if this is not your code style convention.
