### PR TITLE
Add missing license header on one file

### DIFF
--- a/koans/variables-parameters-constants.lsp
+++ b/koans/variables-parameters-constants.lsp
@@ -1,3 +1,17 @@
+;;   Copyright 2013 Google Inc.
+;;
+;;   Licensed under the Apache License, Version 2.0 (the "License");
+;;   you may not use this file except in compliance with the License.
+;;   You may obtain a copy of the License at
+;;
+;;       http://www.apache.org/licenses/LICENSE-2.0
+;;
+;;   Unless required by applicable law or agreed to in writing, software
+;;   distributed under the License is distributed on an "AS IS" BASIS,
+;;   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;;   See the License for the specific language governing permissions and
+;;   limitations under the License.
+
 (defun test-variable-assignment-with-setf ()
   ;; the let pattern allows us to create local variables with
   ;; lexical scope.


### PR DESCRIPTION
 variables-parameters-constants.lsp was missing a license header
 and (at the time of this commit) had only ever been touched by
 the one first commit in 2013, so I added the samed header as in
 the other files, with the same copyright year (2013).