### PR TITLE
Fix example of invocation of ecl in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ From a terminal, execute your lisp interpreter on the file 'contemplate.lsp' e.g
     abcl --noinform --noinit --load contemplate.lsp --eval '(quit)'
     ccl -n -l contemplate.lsp -e '(quit)'
     clisp -q -norc -ansi contemplate.lsp
-    ecl --norc --load contemplate.lsp --eval '(quit)'
+    ecl -norc -load contemplate.lsp -eval '(quit)'
     sbcl --script contemplate.lsp
 
 Running on a fresh version should output the following:


### PR DESCRIPTION
For me, running on Debian Linux, I found the `ecl` invocation specified in the README didn't work because it needed single-hyphen flags rather than double-hyphens. I guess that this behaviour would be the same for `ecl` on most (all?) platforms, but just in case it isn't (meaning both versions would need to be indicated in the README) it would be good to get input from the author of the patch which added the invocation before proceeding - @informatimago does your `ecl` setup require the double-hyphen version? or was it just a typo?