### PR TITLE
Fix docstrings to accomodate clisp

### DIFF
--- a/koans/evaluation.lsp
+++ b/koans/evaluation.lsp
@@ -47,8 +47,8 @@
      but evaluating the form '(+ 1 2) returns the list (+ 1 2)"
   (assert-equal ____ (+ 1 2))
   (assert-equal ____ '(+ 1 2))
-  "'LISTP' is a predicate which returns true if the argument is a list"
-  " the '(CONTENTS) form defines a list literal containing CONTENTS"
+  "'LISTP' is a predicate which returns true if the argument is a list
+   the '(CONTENTS) form defines a list literal containing CONTENTS"
   (assert-equal ___ (listp '(1 2 3)))
   (assert-equal ___ (listp 100))
   (assert-equal ___ (listp "Word to your moms I came to drop bombs"))

--- a/koans/iteration.lsp
+++ b/koans/iteration.lsp
@@ -34,8 +34,8 @@
     (assert-equal ___ how-many-in-list)
     (assert-equal ___ biggest-in-list))
   (let ((sum 0))
-    "write your own dolist here to calculate the sum of some-primes"
-    "you may be interested in investigating the 'incf' function"
+    "write your own dolist here to calculate the sum of some-primes
+     you may be interested in investigating the 'incf' function"
     ;(dolist ... )
     (assert-equal 999607602 sum)))
 


### PR DESCRIPTION
clisp doesn't like multiple docstrings in a row, so fix some.