### PR TITLE
Improve indentation

### DIFF
--- a/koans/asserts.lsp
+++ b/koans/asserts.lsp
@@ -24,24 +24,22 @@
 
 
 (define-test assert-true
-    "t is true.  Replace the blank with a t"
-    (assert-true ___))
+  "t is true.  Replace the blank with a t"
+  (assert-true ___))
 
 (define-test assert-false
-    "nil is false"
-    (assert-false ___))
+  "nil is false"
+  (assert-false ___))
 
 (define-test fill-in-the-blank
-    "sometimes you will need to fill the blank to complete"
-    (assert-equal 2 ___))
+  "sometimes you will need to fill the blank to complete"
+  (assert-equal 2 ___))
 
 (define-test fill-in-the-blank-string
-    (assert-equal ___ "hello world"))
+  (assert-equal ___ "hello world"))
 
 (define-test test-true-or-false
-    "sometimes you will be asked to evaluate whether statements
-     are true (t) or false (nil)"
-    (true-or-false? ___ (equal 34 34))
-    (true-or-false? ___ (equal 19 78)))
-
-
+  "sometimes you will be asked to evaluate whether statements
+are true (t) or false (nil)"
+  (true-or-false? ___ (equal 34 34))
+  (true-or-false? ___ (equal 19 78)))


### PR DESCRIPTION
Bodies of Lisp forms are indented 2 spaces.