### PR TITLE
Fix incorrect scoring project test

### DIFF
--- a/koans/scoring-project.lsp
+++ b/koans/scoring-project.lsp
@@ -81,5 +81,5 @@
     (assert-equal 600  (score '(6 6 6))))
 
 (define-test test-score-of-mixed-is-sum
-    (assert-equal 250  (score '(2 5 2 2 3)))
+    (assert-equal 150  (score '(2 5 2 2 1)))
     (assert-equal 550  (score '(5 5 5 5))))


### PR DESCRIPTION
Given the rules as described, the original first assertion in
`test-score-of-mixed-is-sum` should have returned 50 (one five, no
sequences of threes, no ones).

Assuming that the intent of the test case is to demonstrate that
numbers other than one and five are worth zero points but the values
of ones and fives are summed, this patch changes the final three to a
one, resulting in a score of 150.