### PR TITLE
Fix capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ intent (refactor)."
 
 ## Content
 
-The Common Lisp koans are based on the python koans and ruby koans projects.
+The Common Lisp koans are based on the Python koans and Ruby koans projects.
 Additionally, many of the tests are based on new material that is special
 to Common Lisp.
 


### PR DESCRIPTION
At the bottom of the README:
`python` -> `Python`
`ruby` -> `Ruby`

Reasoning: The language names are properly written this way, and `Common Lisp` is already written with the initial letter of each word in its name capitalized in the project description and README. These changes would adhere to the style followed.

Proposed further change: Capitalize the initial letters of `ruby` and `python` in the project description at the top of the page to adhere to the same style.

All of this is under the assumption that these aren't intentional stylistic choices.