### PR TITLE
Fix regex compilation error in meditate-macos.sh's fswatch call

### DIFF
--- a/meditate-macos.sh
+++ b/meditate-macos.sh
@@ -39,6 +39,6 @@ else
 fi
 
 $CONTEMPLATE
-while fswatch --exclude "\#.*\#" -r1 koans; do
+while fswatch --exclude '#.*#' -r1 koans; do
     $CONTEMPLATE
 done


### PR DESCRIPTION
The line `fswatch --exclude "\#.*\#" -r1 koans` in `meditate-macos.sh` causes the following error:
```
An error occurred during the compilation of \#.*\#
Status code: 2048
```
The PR fixes that by removing the unnecessary escaping of `#`.