### PR TITLE
Fix OR description

### DIFF
--- a/koans/control-statements.lisp
+++ b/koans/control-statements.lisp
@@ -57,7 +57,7 @@
                   x)))
 
 (define-test or-short-circuit
-  ;; AND only evaluates forms until one evaluates to non-NIL.
+  ;; OR only evaluates forms until one evaluates to non-NIL.
   (assert-equal ____
                 (let ((x 0))
                   (or


### PR DESCRIPTION
I just found a small typo.