### PR TITLE
Fix missing "#" in a list of characters

### DIFF
--- a/koans-solved/control-statements.lisp
+++ b/koans-solved/control-statements.lisp
@@ -57,7 +57,7 @@
                   x)))
 
 (define-test or-short-circuit
-  ;; AND only evaluates forms until one evaluates to non-NIL.
+  ;; OR only evaluates forms until one evaluates to non-NIL.
   (assert-equal 2
                 (let ((x 0))
                   (or

--- a/koans-solved/loops.lisp
+++ b/koans-solved/loops.lisp
@@ -17,7 +17,7 @@
 
 (define-test loop-collect
   ;; LOOP can collect the results in various ways.
-  (let* ((result-1 (loop for letter in '(#\a \b #\c #\d) collect letter))
+  (let* ((result-1 (loop for letter in '(#\a #\b #\c #\d) collect letter))
          (result-2 (loop for number in '(1 2 3 4 5) sum number))
          (result-3 (loop for list in '((foo) (bar) (baz)) append list)))
     (assert-equal '(#\a \b #\c #\d) result-1)

--- a/koans/loops.lisp
+++ b/koans/loops.lisp
@@ -17,7 +17,7 @@
 
 (define-test loop-collect
   ;; LOOP can collect the results in various ways.
-  (let* ((result-1 (loop for letter in '(#\a \b #\c #\d) collect letter))
+  (let* ((result-1 (loop for letter in '(#\a #\b #\c #\d) collect letter))
          (result-2 (loop for number in '(1 2 3 4 5) sum number))
          (result-3 (loop for list in '((foo) (bar) (baz)) append list)))
     (assert-equal ____ result-1)


### PR DESCRIPTION
Just spotted what looks like a typo. I guess the intention is to loop over a list of characters, so the list should be `'(#\a #\b #\c #\d)` instead of `'(#\a \b #\c #\d)`.