### PR TITLE
Adjust blanks to be the same length

### DIFF
--- a/koans/functions.lisp
+++ b/koans/functions.lisp
@@ -122,8 +122,8 @@
     (assert-equal ____ (funcall (fourth functions) 2 33))))
 
 (define-test lambda-with-optional-parameters
-  (assert-equal ___ ((lambda (a &optional (b 100)) (+ a b)) 10 9))
-  (assert-equal ___ ((lambda (a &optional (b 100)) (+ a b)) 10)))
+  (assert-equal ____ ((lambda (a &optional (b 100)) (+ a b)) 10 9))
+  (assert-equal ____ ((lambda (a &optional (b 100)) (+ a b)) 10)))
 
 (defun make-adder (x)
   ;; MAKE-ADDER will create a function that closes over the parameter X.

--- a/koans/strings.lisp
+++ b/koans/strings.lisp
@@ -26,7 +26,7 @@
   (let ((string "this is
                  a multi
                  line string"))
-    (true-or-false? ___ (typep string 'string))))
+    (true-or-false? ____ (typep string 'string))))
 
 (define-test escapes-in-strings
   ;; Quotes and backslashes in Lisp strings must be escaped.


### PR DESCRIPTION
This way, the test framework can throw the correct errors for these
tests as it only allows blanks of exactly four underscores.

This way, you also won't miss these when jumping to the next four underscores via searching.