### PR TITLE
Change shebang to /bin/sh

### DIFF
--- a/meditate-macos.sh
+++ b/meditate-macos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ $# != 1 ]; then
     echo "usage: sh meditate.sh <lisp implementation>"


### PR DESCRIPTION
The whole script does not depend on any Bash features,
even README suggests to use sh(1) to run this script.

Also, this script can be used on other non-Linux platforms,
like FreeBSD, where /bin/bash is not available
(Bash is usually installed somewhere else).