### PR TITLE
Fix meditate-macos.sh to stop on Ctrl-C

### DIFF
--- a/meditate-macos.sh
+++ b/meditate-macos.sh
@@ -39,6 +39,6 @@ else
 fi
 
 $CONTEMPLATE
-while fswatch --exclude '#.*#' -r1 koans; do
+while fswatch --exclude '#.*#' -r1 koans | grep .; do
     $CONTEMPLATE
 done


### PR DESCRIPTION
Previously, when a user hit Ctrl-C to send SIGINT to stop the script,
fswatch would exit with 0 anyway. This made the while loop loop forever,
because it was not possible to stop it in an intuitive way.

This patch fixes it by figuring out whether fswatch exited because of a
file system notification or a signal. If fswatch produces no output, it means it
received a signal and exited. If it printed something, it's probably a
path, so it means there is a file change.