### PR TITLE
Adjust position of the blanks

### DIFF
--- a/koans-solved/let.lisp
+++ b/koans-solved/let.lisp
@@ -17,14 +17,14 @@
   ;; created: a symbol that names a variable becomes bound to a value.
   (let ((x 10)
         (y 20))
-    (assert-equal (+ x y) 30)
+    (assert-equal 30 (+ x y))
     ;; It is possible to shadow previously visible bindings.
     (let ((y 30))
-      (assert-equal (+ x y) 40))
-    (assert-equal (+ x y) 30))
+      (assert-equal 40 (+ x y)))
+    (assert-equal 30 (+ x y)))
   ;; Variables bound by LET have a default value of NIL.
   (let (x)
-    (assert-equal x nil)))
+    (assert-equal nil x)))
 
 (define-test let-versus-let*
   ;; LET* is similar to LET, except the bindings are established sequentially,

--- a/koans/let.lisp
+++ b/koans/let.lisp
@@ -17,14 +17,14 @@
   ;; created: a symbol that names a variable becomes bound to a value.
   (let ((x 10)
         (y 20))
-    (assert-equal (+ x y) ____)
+    (assert-equal ____ (+ x y))
     ;; It is possible to shadow previously visible bindings.
     (let ((y 30))
-      (assert-equal (+ x y) ____))
-    (assert-equal (+ x y) ____))
+      (assert-equal ____ (+ x y)))
+    (assert-equal ____ (+ x y)))
   ;; Variables bound by LET have a default value of NIL.
   (let (x)
-    (assert-equal x ____)))
+    (assert-equal ____ x)))
 
 (define-test let-versus-let*
   ;; LET* is similar to LET, except the bindings are established sequentially,


### PR DESCRIPTION
This way, the test framework can throw the correct errors for
this test as it only allows blanks to appear first.

Also, adjust the answer correspondingly.

---

Originally, it shows `FAIL` instead of `INCOMPLETE`.

This change fixed it.