### PR TITLE
Fix triangle function in koans-solved

### DIFF
--- a/koans-solved/triangle-project.lisp
+++ b/koans-solved/triangle-project.lisp
@@ -40,6 +40,7 @@
   (assert-equal :isosceles (triangle 3 4 4))
   (assert-equal :isosceles (triangle 4 3 4))
   (assert-equal :isosceles (triangle 4 4 3))
+  (assert-equal :isosceles (triangle 2 2 3))
   (assert-equal :isosceles (triangle 10 10 2)))
 
 (define-test scalene-triangles

--- a/koans-solved/triangle-project.lisp
+++ b/koans-solved/triangle-project.lisp
@@ -27,6 +27,7 @@
     (cond ((<= (+ min mid) max) (error 'triangle-error :sides (list a b c)))
           ((= max mid min) :equilateral)
           ((= max mid) :isosceles)
+          ((= mid min) :isosceles)
           (t :scalene))))
 
 (define-test equilateral-triangles

--- a/koans/triangle-project.lisp
+++ b/koans/triangle-project.lisp
@@ -30,6 +30,7 @@
   (assert-equal :isosceles (triangle 3 4 4))
   (assert-equal :isosceles (triangle 4 3 4))
   (assert-equal :isosceles (triangle 4 4 3))
+  (assert-equal :isosceles (triangle 2 2 3))
   (assert-equal :isosceles (triangle 10 10 2)))
 
 (define-test scalene-triangles


### PR DESCRIPTION
Fix triangle function logic
Lack of conditions when judging isosceles triangles, for example:
`(triangle 2 2 3)`
It should also be an isosceles triangle.