### PR TITLE
Off-by-one-Error in std-method-comb.lisp 

### DIFF
--- a/koans-solved/std-method-comb.lisp
+++ b/koans-solved/std-method-comb.lisp
@@ -87,7 +87,7 @@
     (assert-equal 3 (remaining-time countdown))
     (assert-equal 2 (remaining-time countdown))
     (assert-equal 1 (remaining-time countdown))
-    (assert-equal 0 (remaining-time countdown))
+    (assert-equal :bang (remaining-time countdown))
     (assert-equal :bang (remaining-time countdown))
     (assert-equal :bang (remaining-time countdown))))
 

--- a/koans-solved/std-method-comb.lisp
+++ b/koans-solved/std-method-comb.lisp
@@ -76,7 +76,7 @@
 
 (defmethod remaining-time :around ((object countdown))
   (let ((time (call-next-method)))
-    (if (< 0 time)
+    (if (< 1 time)
         ;; DECF is similar to INCF. It decreases the value stored in the place
         ;; and returns the decreased value.
         (decf (slot-value object 'remaining-time))

--- a/koans-solved/std-method-comb.lisp
+++ b/koans-solved/std-method-comb.lisp
@@ -76,18 +76,21 @@
 
 (defmethod remaining-time :around ((object countdown))
   (let ((time (call-next-method)))
-    (if (< 1 time)
+    (if (< 0 time)
         ;; DECF is similar to INCF. It decreases the value stored in the place
         ;; and returns the decreased value.
-        (decf (slot-value object 'remaining-time))
+        ;; PROG1 returns the value of the first expression in the sequence.
+        (prog1
+          (slot-value object 'remaining-time)
+          (decf (slot-value object 'remaining-time)))
         :bang)))
 
 (define-test countdown
   (let ((countdown (make-instance 'countdown :time 4)))
+    (assert-equal 4 (remaining-time countdown))
     (assert-equal 3 (remaining-time countdown))
     (assert-equal 2 (remaining-time countdown))
     (assert-equal 1 (remaining-time countdown))
-    (assert-equal :bang (remaining-time countdown))
     (assert-equal :bang (remaining-time countdown))
     (assert-equal :bang (remaining-time countdown))))
 

--- a/koans-solved/std-method-comb.lisp
+++ b/koans-solved/std-method-comb.lisp
@@ -77,11 +77,11 @@
 (defmethod remaining-time :around ((object countdown))
   (let ((time (call-next-method)))
     (if (< 0 time)
+        ;; PROG1 returns the value of the first expression in the sequence.
         ;; DECF is similar to INCF. It decreases the value stored in the place
         ;; and returns the decreased value.
-        ;; PROG1 returns the value of the first expression in the sequence.
         (prog1
-          (slot-value object 'remaining-time)
+          time
           (decf (slot-value object 'remaining-time)))
         :bang)))
 

--- a/koans/std-method-comb.lisp
+++ b/koans/std-method-comb.lisp
@@ -76,7 +76,7 @@
 
 (defmethod remaining-time :around ((object countdown))
   (let ((time (call-next-method)))
-    (if (< 0 time)
+    (if (< 1 time)
         ;; DECF is similar to INCF. It decreases the value stored in the place
         ;; and returns the decreased value.
         (decf (slot-value object 'remaining-time))

--- a/koans/std-method-comb.lisp
+++ b/koans/std-method-comb.lisp
@@ -76,15 +76,18 @@
 
 (defmethod remaining-time :around ((object countdown))
   (let ((time (call-next-method)))
-    (if (< 1 time)
+    (if (< 0 time)
         ;; DECF is similar to INCF. It decreases the value stored in the place
         ;; and returns the decreased value.
-        (decf (slot-value object 'remaining-time))
+        ;; PROG1 returns the value of the first expression in the sequence.
+        (prog1
+          (slot-value object 'remaining-time)
+          (decf (slot-value object 'remaining-time)))
         :bang)))
 
 (define-test countdown
   (let ((countdown (make-instance 'countdown :time 4)))
-    (assert-equal 3 (remaining-time countdown))
+    (assert-equal 4 (remaining-time countdown))
     (assert-equal ____ (remaining-time countdown))
     (assert-equal ____ (remaining-time countdown))
     (assert-equal ____ (remaining-time countdown))

--- a/koans/std-method-comb.lisp
+++ b/koans/std-method-comb.lisp
@@ -77,11 +77,11 @@
 (defmethod remaining-time :around ((object countdown))
   (let ((time (call-next-method)))
     (if (< 0 time)
+        ;; PROG1 returns the value of the first expression in the sequence.
         ;; DECF is similar to INCF. It decreases the value stored in the place
         ;; and returns the decreased value.
-        ;; PROG1 returns the value of the first expression in the sequence.
         (prog1
-          (slot-value object 'remaining-time)
+          time
           (decf (slot-value object 'remaining-time)))
         :bang)))
 


### PR DESCRIPTION
As in the description above noted:
```
  ;; The countdown object represents an ongoing countdown. Each time the
  ;; REMAINING-TIME function is called, it should return a number one less than
  ;; the previous time that it returned. If the countdown hits zero, :BANG
  ;; should be returned instead.
```
Thus, the :BANG-clause should execute one function call earlier.