### PR TITLE
Fix a warning due to a blank specified as _____ rather than ____

### DIFF
--- a/koans/backquote.lisp
+++ b/koans/backquote.lisp
@@ -54,7 +54,7 @@
     (true-or-false? ____ (equal '(1 3 5) `(1 3 5)))
     (true-or-false? ____ (equal '(1 3 5) `(1 3 number)))
     (assert-equal ____ `(1 3 ,number))
-    (assert-equal _____ `(word ,word ,word word))))
+    (assert-equal ____ `(word ,word ,word word))))
 
 (define-test splicing
   (let ((axis '(x y z)))


### PR DESCRIPTION
I was thrown off thinking I'd created an error with my previous change, when I'd only revealed it.

SBCL 2.3.2 says:

```
; in: LAMBDA ()
;     (LISP-KOANS.TEST:ASSERT-EQUAL LISP-KOANS.KOANS.BACKQUOTE::_____
;                                   `(LISP-KOANS.KOANS.BACKQUOTE::WORD
;                                     ,LISP-KOANS.KOANS.BACKQUOTE::WORD
;                                     ,LISP-KOANS.KOANS.BACKQUOTE::WORD
;                                     LISP-KOANS.KOANS.BACKQUOTE::WORD))
; --> LISP-KOANS.TEST::INTERNAL-ASSERT LAMBDA
; ==>
;   #'(LAMBDA () LISP-KOANS.KOANS.BACKQUOTE::_____)
;
; caught WARNING:
;   undefined variable: LISP-KOANS.KOANS.BACKQUOTE::_____
;
; compilation unit finished
;   Undefined variable:
;     LISP-KOANS.KOANS.BACKQUOTE::_____
;   caught 1 WARNING condition
```