### PR TITLE
Update threads.lisp in koans and koans-solved

### DIFF
--- a/koans/threads.lisp
+++ b/koans/threads.lisp
@@ -109,13 +109,15 @@
 
 ;;; We can further orchestrate threads by using semaphores.
 
-(defvar *semaphore* (bt:make-semaphore))
+(defvar *semaphore* (bt-sem:make-semaphore))
 
 (defun signal-our-semaphore ()
-  (bt:signal-semaphore semaphore))
+  (bt-sem:signal-semaphore *semaphore*)
+  (bt-sem:semaphore-count *semaphore*)
 
 (defun wait-on-our-semaphore ()
-  (bt:wait-on-semaphore semaphore :timeout 100))
+  (bt-sem:wait-on-semaphore *semaphore* :timeout 100)
+  (bt-sem:semaphore-count *semaphore))
 
 (define-test semaphore
   (assert-equal 1 (bt:join-thread (bt:make-thread #'signal-our-semaphore)))


### PR DESCRIPTION
1. Update semaphore related code in koans/threads.lisp to return count.
2. Update koans-solved/threads.lisp with SBCL 2.2.9 (Win 10) run result.

Furthermore, cannot access the [cla site](https://cla.developers.google.com/) to sign.